### PR TITLE
add constant and filter features, improve parameters

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gurkha",
-  "version": "1.1.1",
+  "version": "2.0.0",
   "description": "Data extraction module",
   "main": "gurkha.js",
   "scripts": {


### PR DESCRIPTION
Parameters are now passed together with the cheerio options. Format changed to object from array, and are now also used by sanitizer and filter functions. Can also be overriden by passing an object to a .parse() call.
